### PR TITLE
Raise the error if an error is returned when resolving a field

### DIFF
--- a/lib/rspec/graphql_types.rb
+++ b/lib/rspec/graphql_types.rb
@@ -55,6 +55,7 @@ module Rspec
       value = context.dataloader.run_isolated do
         graphql_field.resolve(object, arguments, context)
       end
+      raise value if value.is_a?(Exception)
       graphql_object(graphql_field.type, value)
     end
 


### PR DESCRIPTION
This is used to test field level access restrictions when using the GraphQL Pundit integration