### PR TITLE
Fix compatibility issues with GraphQL gem v2.0.0 - v2.0.17.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,38 @@
 PATH
   remote: .
   specs:
-    rspec-graphql_types (1.0.3)
+    rspec-graphql_types (1.0.5)
       activesupport
       graphql
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.9)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     diff-lcs (1.4.4)
-    graphql (1.12.16)
-    i18n (1.8.10)
+    drb (2.2.1)
+    fiber-storage (1.0.0)
+    graphql (2.3.19)
+      base64
+      fiber-storage
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.4)
+    logger (1.6.1)
+    minitest (5.25.1)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -34,12 +47,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    tzinfo (2.0.4)
+    securerandom (0.3.1)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-23
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-graphql_types (1.0.5)
+    rspec-graphql_types (1.0.6)
       activesupport
       graphql
 

--- a/lib/rspec/graphql_types.rb
+++ b/lib/rspec/graphql_types.rb
@@ -8,7 +8,7 @@ module Rspec
   module GraphQLTypes
     extend ActiveSupport::Concern
 
-    class TestQuery < GraphQL::Query::NullContext::NullQuery
+    class TestQuery < ::GraphQL::Query::NullContext::NullQuery
       def trace(_key, _data)
         yield
       end
@@ -24,7 +24,8 @@ module Rspec
 
     included do
       let(:context_values) { nil }
-      let(:context) { GraphQL::Query::Context.new(query: TestQuery.new, values: context_values, object: nil, schema: GraphQLTypes.schema_class.new) }
+      let(:schema) { ::GraphQL::VERSION.start_with?("1") ? GraphQLTypes.schema_class.new : GraphQLTypes.schema_class }
+      let(:context) { ::GraphQL::Query::Context.new(query: TestQuery.new, values: context_values, object: nil, schema: schema) }
     end
 
     def graphql_object(type, value)
@@ -73,7 +74,7 @@ module Rspec
     end
 
     def self.schema_class
-      schemas = GraphQL::Schema.subclasses.filter { |schema| !schema.name.start_with?("GraphQL::") }
+      schemas = ::GraphQL::Schema.subclasses.filter { |schema| !schema.name.start_with?("GraphQL::") }
       raise "Could not find valid schema. Please ensure that GraphQL::Schema.subclasses returns a single schema" unless schemas.length == 1
       schemas.first
     end

--- a/lib/rspec/graphql_types/version.rb
+++ b/lib/rspec/graphql_types/version.rb
@@ -2,6 +2,6 @@
 
 module Rspec
   module GraphQLTypes
-    VERSION = "1.0.5"
+    VERSION = "1.0.6"
   end
 end


### PR DESCRIPTION
This fixes the compatibility issue with GraphQL v2.0.0 - v2.0.17.2

Issue: https://github.com/gaia-venture/rspec-graphql_types/issues/5

From GraphQL v2.0 the schema is expected to be a schema class rather than an instance. We can change the behaviour according to the version from within the GraphQL gem. 
